### PR TITLE
fix: invalid table crashes the toMarkdown conversion bug

### DIFF
--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -222,7 +222,9 @@ class Table {
     }
 
     // stop processing if no columns found
-    if (cols.length === 0) return '';
+    if (cols.length === 0) {
+      return '';
+    }
 
     const numCols = cols.length;
 

--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -230,9 +230,11 @@ class Table {
       }
     }
 
-    // populate the columns with default max widths
-    for (const [d, idx] of distribute(this.opts.width, numCols)) {
-      cols[idx].maxWidth = d;
+    if (numCols > 0) {
+      // populate the columns with default max widths
+      for (const [d, idx] of distribute(this.opts.width, numCols)) {
+        cols[idx].maxWidth = d;
+      }
     }
 
     // render cells

--- a/src/to-markdown.js
+++ b/src/to-markdown.js
@@ -221,6 +221,9 @@ class Table {
       }
     }
 
+    // stop processing if no columns found
+    if (cols.length === 0) return '';
+
     const numCols = cols.length;
 
     // add empty cells if needed
@@ -230,11 +233,9 @@ class Table {
       }
     }
 
-    if (numCols > 0) {
-      // populate the columns with default max widths
-      for (const [d, idx] of distribute(this.opts.width, numCols)) {
-        cols[idx].maxWidth = d;
-      }
+    // populate the columns with default max widths
+    for (const [d, idx] of distribute(this.opts.width, numCols)) {
+      cols[idx].maxWidth = d;
     }
 
     // render cells

--- a/test/fixtures/gt-invalid.md
+++ b/test/fixtures/gt-invalid.md
@@ -1,0 +1,3 @@
+## Invalid Grid Table
+
++

--- a/test/fixtures/gt-invalid.md
+++ b/test/fixtures/gt-invalid.md
@@ -1,3 +1,2 @@
 ## Invalid Grid Table
 
-+

--- a/test/gridtable-to-md.test.js
+++ b/test/gridtable-to-md.test.js
@@ -171,6 +171,22 @@ describe('gridtable to md', () => {
     await assertMD(mdast, 'gt-simple.md');
   });
 
+  it('invalid table - empty table', async () => {
+    const mdast = root([
+      heading(2, text('Invalid Grid Table')),
+      gridTable(),
+    ]);
+    await assertMD(mdast, 'gt-invalid.md');
+  });
+
+  it('invalid table - empty row', async () => {
+    const mdast = root([
+      heading(2, text('Invalid Grid Table')),
+      gridTable([]),
+    ]);
+    await assertMD(mdast, 'gt-invalid.md');
+  });
+
   it('footer but no header table', async () => {
     const mdast = root([
       heading(2, text('Grid Table no header')),


### PR DESCRIPTION
Fix #22

The conversion output of an invalid table (no columns found) is an empty string. Naturally, this is not bidirectional, it just makes sure the conversion does not crash.
